### PR TITLE
Xcode 12.5 Fix

### DIFF
--- a/Common/XCTest.h
+++ b/Common/XCTest.h
@@ -240,3 +240,47 @@ struct __va_list_tag {
 @interface NSValue (XCTestAdditions)
 - (id)xct_contentDescription;
 @end
+
+@interface XCTTestIdentifier : NSObject <NSCopying, NSSecureCoding>
+
++ (_Bool)supportsSecureCoding;
++ (id)allocWithZone:(struct _NSZone *)arg1;
++ (id)bundleIdentifier;
++ (id)identifierForClass:(Class)arg1;
++ (id)leafIdentifierWithComponents:(id)arg1;
++ (id)containerIdentifierWithComponents:(id)arg1;
++ (id)containerIdentifierWithComponent:(id)arg1;
+- (Class)classForCoder;
+- (void)encodeWithCoder:(id)arg1;
+- (id)initWithCoder:(id)arg1;
+@property(readonly) unsigned long long options;
+- (id)componentAtIndex:(unsigned long long)arg1;
+@property(readonly) unsigned long long componentCount;
+@property(readonly) NSArray *components;
+- (id)initWithComponents:(id)arg1 options:(unsigned long long)arg2;
+- (id)initWithStringRepresentation:(id)arg1 preserveModulePrefix:(_Bool)arg2;
+- (id)initWithStringRepresentation:(id)arg1;
+- (id)initWithClassName:(id)arg1;
+- (id)initWithClassName:(id)arg1 methodName:(id)arg2;
+- (id)initWithClassAndMethodComponents:(id)arg1;
+- (id)initWithComponents:(id)arg1 isContainer:(_Bool)arg2;
+- (id)copyWithZone:(struct _NSZone *)arg1;
+@property(readonly) XCTTestIdentifier *swiftMethodCounterpart;
+@property(readonly) XCTTestIdentifier *firstComponentIdentifier;
+@property(readonly) XCTTestIdentifier *parentIdentifier;
+- (id)_identifierString;
+@property(readonly) NSString *identifierString;
+@property(readonly) NSString *displayName;
+@property(readonly) NSString *lastComponentDisplayName;
+@property(readonly) NSString *lastComponent;
+@property(readonly) NSString *firstComponent;
+@property(readonly) _Bool representsBundle;
+@property(readonly) _Bool isLeaf;
+@property(readonly) _Bool isContainer;
+- (unsigned long long)hash;
+- (id)debugDescription;
+- (id)description;
+@property(readonly) _Bool isSwiftMethod;
+@property(readonly) _Bool usesClassAndMethodSemantics;
+
+@end

--- a/otest-query/otest-query.xcodeproj/project.pbxproj
+++ b/otest-query/otest-query.xcodeproj/project.pbxproj
@@ -63,6 +63,9 @@
 		CCEF651C1F5CD57800283B7E /* OtestQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = CC12CBF118E54A1400AA76E9 /* OtestQuery.h */; };
 		CD66612D175D1A890057DF4D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD9049011756C5B1006CF16D /* Foundation.framework */; };
 		CD9049021756C5B1006CF16D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD9049011756C5B1006CF16D /* Foundation.framework */; };
+		D442ACCC26A76AC700EEF6DF /* XCTest.h in Headers */ = {isa = PBXBuildFile; fileRef = D442ACCB26A76AC700EEF6DF /* XCTest.h */; };
+		D442ACCD26A76AC700EEF6DF /* XCTest.h in Headers */ = {isa = PBXBuildFile; fileRef = D442ACCB26A76AC700EEF6DF /* XCTest.h */; };
+		D442ACCE26A76AC700EEF6DF /* XCTest.h in Headers */ = {isa = PBXBuildFile; fileRef = D442ACCB26A76AC700EEF6DF /* XCTest.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -135,6 +138,7 @@
 		CD9049011756C5B1006CF16D /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		CD90490F1756C685006CF16D /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		CD9049151756CDF4006CF16D /* otest-query-ios.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "otest-query-ios.xcconfig"; sourceTree = "<group>"; };
+		D442ACCB26A76AC700EEF6DF /* XCTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XCTest.h; path = ../Common/XCTest.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -223,6 +227,7 @@
 				AA318BE317E9A8C000BF159E /* TestingFramework.h */,
 				AA318BE517E9AA7400BF159E /* TestingFramework.m */,
 				28EC25F9184EAA680061C3B2 /* XcodeRequiredVersion.m */,
+				D442ACCB26A76AC700EEF6DF /* XCTest.h */,
 			);
 			name = Common;
 			sourceTree = "<group>";
@@ -310,6 +315,7 @@
 				CC8D774C19660E230035CC60 /* NSInvocationInSetFix.h in Headers */,
 				AA318BE417E9A8C000BF159E /* TestingFramework.h in Headers */,
 				2887CC35181DDB5F00B0D049 /* Swizzle.h in Headers */,
+				D442ACCD26A76AC700EEF6DF /* XCTest.h in Headers */,
 				2887CC3B181E0D8600B0D049 /* DuplicateTestNameFix.h in Headers */,
 				CC12CBF318E54A1400AA76E9 /* OtestQuery.h in Headers */,
 			);
@@ -319,6 +325,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D442ACCE26A76AC700EEF6DF /* XCTest.h in Headers */,
 				CC8D774D19660E230035CC60 /* NSInvocationInSetFix.h in Headers */,
 				CC12CBF418E54A1400AA76E9 /* OtestQuery.h in Headers */,
 			);
@@ -331,6 +338,7 @@
 				CCEF65181F5CD57800283B7E /* NSInvocationInSetFix.h in Headers */,
 				CCEF65191F5CD57800283B7E /* TestingFramework.h in Headers */,
 				CCEF651A1F5CD57800283B7E /* Swizzle.h in Headers */,
+				D442ACCC26A76AC700EEF6DF /* XCTest.h in Headers */,
 				CCEF651B1F5CD57800283B7E /* DuplicateTestNameFix.h in Headers */,
 				CCEF651C1F5CD57800283B7E /* OtestQuery.h in Headers */,
 			);

--- a/xctool/xctool/OCTestEventState.h
+++ b/xctool/xctool/OCTestEventState.h
@@ -36,7 +36,7 @@
 
 - (instancetype)initWithInputName:(NSString *)name;
 
-- (NSString *)testName;
+- (NSString *)testIdentifier;
 - (void)stateBeginTest;
 - (void)stateEndTest:(BOOL)successful result:(NSString *)result;
 - (void)stateEndTest:(BOOL)successful result:(NSString *)result duration:(double)duration;

--- a/xctool/xctool/OCTestEventState.m
+++ b/xctool/xctool/OCTestEventState.m
@@ -57,9 +57,9 @@
   _methodName = [parts[1] copy];
 }
 
-- (NSString *)testName
+- (NSString *)testIdentifier
 {
-  return [NSString stringWithFormat:@"-[%@ %@]", _className, _methodName];
+  return [NSString stringWithFormat:@"%@/%@", _className, _methodName];
 }
 
 - (BOOL)isRunning
@@ -125,7 +125,7 @@
     [self stateBeginTest];
     [self publishWithEvent:
       EventDictionaryWithNameAndContent(kReporter_Events_BeginTest, @{
-        kReporter_EndTest_TestKey:[self testName],
+        kReporter_EndTest_TestKey:[self testIdentifier],
         kReporter_EndTest_ClassNameKey:_className,
         kReporter_EndTest_MethodNameKey:_methodName,
     })];
@@ -138,7 +138,7 @@
     [self stateEndTest:NO result:@"error"];
     [self publishWithEvent:
       EventDictionaryWithNameAndContent(kReporter_Events_EndTest, @{
-        kReporter_EndTest_TestKey:[self testName],
+        kReporter_EndTest_TestKey:[self testIdentifier],
         kReporter_EndTest_ClassNameKey:_className,
         kReporter_EndTest_MethodNameKey:_methodName,
         kReporter_EndTest_SucceededKey:@(_isSuccessful),

--- a/xctool/xctool/OCTestSuiteEventState.m
+++ b/xctool/xctool/OCTestSuiteEventState.m
@@ -187,7 +187,7 @@
 - (OCTestEventState *)getTestWithTestName:(NSString *)name
 {
   NSUInteger idx = [_tests indexOfObjectPassingTest:^(OCTestEventState *test, NSUInteger index, BOOL *stop) {
-    return [[test testName] isEqualToString:name];
+    return [[test testIdentifier] isEqualToString:name];
   }];
 
   if (idx == NSNotFound) {

--- a/xctool/xctool/OCUnitTestRunner.m
+++ b/xctool/xctool/OCUnitTestRunner.m
@@ -22,6 +22,7 @@
 #import "TestRunState.h"
 #import "XcodeBuildSettings.h"
 #import "XCTestConfiguration.h"
+#import "XCTest.h"
 #import "XCToolUtil.h"
 
 static NSString * const kEnvVarPassThroughPrefix = @"XCTOOL_TEST_ENV_";
@@ -361,7 +362,12 @@ static NSString * const kEnvVarPassThroughPrefix = @"XCTOOL_TEST_ENV_";
 
   Class XCTestIdentifierSetClass = NSClassFromString(@"XCTTestIdentifierSet");
   if (XCTestIdentifierSetClass) {
-    id identifierSet = [[XCTestIdentifierSetClass alloc] initWithSet:[NSSet setWithArray:testCasesToSkip]];
+    NSMutableArray *skippedIdentifiers = [NSMutableArray arrayWithCapacity:[testCasesToSkip count]];
+    [testCasesToSkip enumerateObjectsUsingBlock:^(NSString *str, NSUInteger idx, BOOL *stop) {
+      XCTTestIdentifier *testIdentifier = [[XCTTestIdentifier alloc] initWithStringRepresentation:str];
+      [skippedIdentifiers addObject:testIdentifier];
+    }];
+    id identifierSet = [[XCTestIdentifierSetClass alloc] initWithArray:skippedIdentifiers];
     configuration.testsToSkip = identifierSet;
   } else {
     configuration.testsToSkip = [NSSet setWithArray:testCasesToSkip];

--- a/xctool/xctool/TestRunState.m
+++ b/xctool/xctool/TestRunState.m
@@ -245,7 +245,7 @@
                               @"likely responsible for the crash.\n"
                               @"\n"
                               @"%@",
-                              [_previousTestState testName],
+                              [_previousTestState testIdentifier],
                               [self collectCrashReports:_crashReportsAtStart]];
   fakeTestOutput = [fakeTestOutput stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 


### PR DESCRIPTION
Xctool depends on the private implementation of Apple's `XCTest.framework`. In Xcode 12.5, the test cases are identified a newly added class `XCTTestIdentifier` instead of a string. This PR accommodates this change in `xctool`.