### PR TITLE
Stop dropping data through named pipe in rare circumstances

### DIFF
--- a/xctool/xctool/OCUnitIOSLogicTestRunner.m
+++ b/xctool/xctool/OCUnitIOSLogicTestRunner.m
@@ -98,8 +98,7 @@ static NSString * const XCTOOL_TMPDIR = @"TMPDIR";
   }];
 
   // specify a path where to write otest-shim events
-  NSString *outputPath = MakeTempFileWithPrefix(@"output");
-  [[NSFileManager defaultManager] removeItemAtPath:outputPath error:nil];
+  NSString *outputPath = [TemporaryDirectoryForAction() stringByAppendingPathComponent:@"otest-shim-events"];
   env[@"OTEST_SHIM_STDOUT_FILE"] = outputPath;
   *otestShimOutputPath = outputPath;
 


### PR DESCRIPTION
On a couple of machines we saw an issue where the test suite would end before it began. We would notice this assertion. https://github.com/qyang-nj/xctool/blob/b6055b5341dc270f38e04c8da44010e0695b5113/xctool/xctool/OCTestSuiteEventState.m#L57

In debugging the issue we found that we were creating a temporary file at the location of the named pipe. https://github.com/qyang-nj/xctool/blob/b6055b5341dc270f38e04c8da44010e0695b5113/Common/XCToolUtil.m#L233-L235

This temporary file was then immediately deleted, as you can see in the diff.

If we added a `sleep(5);` between the deletion of the temporarily file and when we made the named pipe, we also saw the issue resolved.

This PR feels like a cleaner fix. If we aren't using the file in this code path, there is no need to create and delete it. We don't fully understand the root cause.

@qyang-nj 