### PR TITLE
Force `simctl spawn` to run x86_64 arch

### DIFF
--- a/xctool/xctool/SimulatorWrapper/SimulatorTaskUtils.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorTaskUtils.m
@@ -35,6 +35,9 @@ NSTask *CreateTaskForSimulatorExecutable(NSString *sdkName,
       [sdkName hasPrefix:@"appletvsimulator"]) {
     SimDevice *simulatedDevice = [simulatorInfo simulatedDevice];
     [taskArgs addObject: @"spawn"];
+    // Airbnb: force to run x86_64 xctest on M1 machine.
+    // This breaks test bundles that are built natively for arm64, but we don't have any of them for now.
+    [taskArgs addObject: @"--arch=x86_64"];
     if (ToolchainIsXcode10OrBetter() && [simulatedDevice state] != SimDeviceStateBooted) {
       // If simulator is not booted, pass --standalone option, which is required by Xcode 11.
       [taskArgs addObject: @"--standalone"];


### PR DESCRIPTION
Force `simctl spawn` to run x86_64 arch, which allows us running x86_64 test bundle on M1 machines. This change will break any test bundle that is built natively for arm64, but right now we only have x86_64 tests.

Ideally, we should detect the test binary's architecture on the fly and pass corresponding arch to the `simctl spawn`. This is much more complicated than a one-line change. We can add this when we need to (if we're still using `xctool` at that time).

#### Please review
@shepting